### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ There is a single directive exposed to create the confirmation popover, use it l
 An explanation of the properties is as follows:
 
 #### title
-The title of the popover. This value is interpolated.
+The title of the popover. This value is interpolated. Note, if you use an expression, you may want to consider using "data-title" instead of "title" so that the browser doesn't show native tooltips with the angular expression listed.
 
 #### message
 The body text of the popover. This value is interpolated.


### PR DESCRIPTION
Added a note on the "title" documentation to warn users they may want to consider prefixing the "title" attribute with "data-" (data-title) so that the browser doesn't show native tooltips - which would include the angular expression (curly braces).