### PR TITLE
Bugfix: Imbriqued modals not displaying confirm box

### DIFF
--- a/src/angular-bootstrap-confirm.js
+++ b/src/angular-bootstrap-confirm.js
@@ -81,6 +81,7 @@ module.exports = angular
       if (!vm.isVisible && !evaluateOuterScopeValue($attrs.isDisabled, false)) {
         popoverLoaded.then(function(popover) {
           popover.css({display: 'block'});
+          popover.css({'z-index': '10000'});
           if (animation) {
             $animate.addClass(popover, 'in');
           }


### PR DESCRIPTION
In bootstrap imbriqued modals (>=3 modals), confirmation box shows in the wrong
modal (and is therefore hidden).

This minor solution I am currently using is not pretty but works.